### PR TITLE
6/api requests endpoint

### DIFF
--- a/controllers/RequestController.js
+++ b/controllers/RequestController.js
@@ -27,7 +27,28 @@ function getByShortId(req, res) {
     });
 }
 
+function getByQueryParams(req, res){
+    // add request query params
+    var query = {};
+    for(param in req.query){
+        query[param] = req.query[param];
+    }
+    Request.find(query).then((docs) => {
+        if(docs.length > 0){
+            res.status(200).send( docs );
+        }else{
+            res.status(404).send({ error: 404, message: 'No documents matching criteria'});
+        }
+    }).catch((err) => {
+        res.status(500).send(Object.assign(
+            { error: 500, message: 'Server error'},
+            err,
+        ));
+    });
+}
+
 module.exports = {
     create,
     getByShortId,
+    getByQueryParams
 }

--- a/controllers/RequestController.js
+++ b/controllers/RequestController.js
@@ -28,12 +28,27 @@ function getByShortId(req, res) {
 }
 
 function getByQueryParams(req, res){
-    // add request query params
     var query = {};
+    var sortBy = {};
+    var limit = 25;
+    // add request query params
     for(param in req.query){
-        query[param] = req.query[param];
+        if(["limit","sortBy"].indexOf(param) < 0){
+            query[param] = req.query[param];
+        }
     }
-    Request.find(query).then((docs) => {
+    // limit to 25 by docs by default, "limit" query param overwrites this value
+    var re = /^[0-9]*$/i;
+    if(req.query.hasOwnProperty('limit') && req.query.limit.match(re)){
+        limit = parseInt(req.query.limit);
+    }
+    // sortBy by one field
+    var re = /^[-|+]+[a-zA-Z0-9]*$/i;
+    if(req.query.hasOwnProperty('sortBy') && req.query.limit.match(re)){
+        sortBy = req.query[param];
+    }
+    // query the schema
+    Request.find(query).limit(limit).sort(sortBy).then((docs) => {
         if(docs.length > 0){
             res.status(200).send( docs );
         }else{

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -8,6 +8,7 @@ routes.get('/', function (req, res) {
 // Food Requests
 routes.post('/request', RequestControlller.create);
 routes.get('/request/:shortId', RequestControlller.getByShortId);
+routes.get('/requests', RequestControlller.getByQueryParams);
 
 routes.all('*', function (req, res) {
     res.status(404).send({error: 404, message: 'invalid endpoint'});


### PR DESCRIPTION
# Solves issue Number: #6

## Description
Exposes ```/api/requests``` endpoint to get a list of food requests.

It supports:
- Filtering requests with multiple ```and``` query params
- Limit the number of rows with param ```limit``` defaults to 25.
- Sort results by one field with ```sortBy``` query param.

## Todos
The following things are missing for feature completeness:
- [ ] Implement ```like``` filters
- [ ] Implement advanced filtering by ranges in numeric fields

## Steps to Test or Reproduce

Example requests:
- http://localhost:3000/api/requests?status=pending
- http://localhost:3000/api/requests?status=new&email=techforpr@example.com
- http://localhost:3000/api/requests?status=new&email=techforpr@example.com&needs.breakfast=10&limit=5&sortBy=-createdAt

## Impacted Areas in Application

Provides the base endpoint for #7 and #9







