### PR TITLE
fix(models): virtual fields on Delivery

### DIFF
--- a/models/Delivery.js
+++ b/models/Delivery.js
@@ -60,8 +60,6 @@ const Delivery = new Schema({
         default: false,
     }
 }, {
-    toObject: { virtuals: true },
-    toJSON: { virtuals: true },
     timestamps: true,
 });
 
@@ -84,15 +82,18 @@ Delivery.statics.createForm = function (labels) {
 }
 
 Delivery.virtual('createdOn').get(function () {
-    return moment(this.createdAt).format(longDateFormat);
+    const delivery = this.toObject();
+    return moment(delivery.createdAt).format(longDateFormat);
 });
 
 Delivery.virtual('lastDayOfDeliveryParsed').get(function () {
-    return moment(this.lastDayOfDelivery).format(longDateFormat);
+    const delivery = this.toObject();
+    return moment(delivery.lastDayOfDelivery).format(longDateFormat);
 });
 
 Delivery.virtual('createdOnParsed').get(function () {
-    return moment(this.createdOn).format(longDateFormat);
+    const delivery = this.toObject();
+    return moment(delivery.createdOn).format(longDateFormat);
 });
 
 Delivery.pre("save", function(next) {


### PR DESCRIPTION
# Solves issue Number:

#45 

## Description

Fixes a reference to the Delivery model when establishing the virtual fields. "this" was empty when attempting to format the lastDayOfDelivery field - however, calling "toJSON" or "toObject" on them was resulting in an infinite loop because schema hooks included virtuals (now disabled).

## Steps to Test or Reproduce

To see the changes please...

* Create / Schedule a delivery and see that the date accurately reflects the last day for delivery.






